### PR TITLE
Combobox input ref gadget hacks

### DIFF
--- a/documentation-site/components/yard/config/combobox.ts
+++ b/documentation-site/components/yard/config/combobox.ts
@@ -100,6 +100,11 @@ const ComboboxConfig: TConfig = {
       value: undefined,
       type: PropTypes.String,
       description: 'Name attribute.',
+    },
+    inputRef: {
+      value: undefined,
+      type: PropTypes.Ref,
+      description: 'A ref to access the input element.',
       hidden: true,
     },
 

--- a/documentation-site/examples/combobox/focus.js
+++ b/documentation-site/examples/combobox/focus.js
@@ -1,0 +1,56 @@
+// @flow
+
+import * as React from 'react';
+
+import {useStyletron} from 'baseui';
+import {Combobox} from 'baseui/combobox';
+import {FormControl} from 'baseui/form-control';
+import {Button} from 'baseui/button';
+
+type OptionT = {label: string, id: string};
+const options: OptionT[] = [
+  {label: 'AliceBlue', id: '#F0F8FF'},
+  {label: 'AntiqueWhite', id: '#FAEBD7'},
+  {label: 'Aqua', id: '#00FFFF'},
+  {label: 'Aquamarine', id: '#7FFFD4'},
+  {label: 'Azure', id: '#F0FFFF'},
+  {label: 'Beige', id: '#F5F5DC'},
+];
+
+function Example() {
+  const [css, theme] = useStyletron();
+  const [value, setValue] = React.useState('');
+  const inputRef = React.useRef(null);
+  return (
+    <div className={css({display: 'flex', flexDirection: 'row'})}>
+      <span>
+        <FormControl label="Color">
+          <Combobox
+            value={value}
+            onChange={setValue}
+            mapOptionToString={o => o.label}
+            options={options}
+            inputRef={inputRef}
+            overrides={{
+              Root: {
+                style: {
+                  width: '375px',
+                  marginRight: theme.sizing.scale600,
+                },
+              },
+            }}
+          />
+        </FormControl>
+      </span>
+      <Button
+        onClick={() => {
+          inputRef.current && inputRef.current.focus();
+        }}
+      >
+        Click to focus
+      </Button>
+    </div>
+  );
+}
+
+export default Example;

--- a/documentation-site/examples/combobox/focus.tsx
+++ b/documentation-site/examples/combobox/focus.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+
+import {useStyletron} from 'baseui';
+import {Combobox} from 'baseui/combobox';
+import {FormControl} from 'baseui/form-control';
+import {Button} from 'baseui/button';
+
+type OptionT = {label: string; id: string};
+const options: OptionT[] = [
+  {label: 'AliceBlue', id: '#F0F8FF'},
+  {label: 'AntiqueWhite', id: '#FAEBD7'},
+  {label: 'Aqua', id: '#00FFFF'},
+  {label: 'Aquamarine', id: '#7FFFD4'},
+  {label: 'Azure', id: '#F0FFFF'},
+  {label: 'Beige', id: '#F5F5DC'},
+];
+
+function Example() {
+  const [css, theme] = useStyletron();
+  const [value, setValue] = React.useState('');
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  return (
+    <div className={css({display: 'flex', flexDirection: 'row'})}>
+      <span>
+        <FormControl label="Color">
+          <Combobox
+            value={value}
+            onChange={setValue}
+            mapOptionToString={o => o.label}
+            options={options}
+            inputRef={inputRef}
+            overrides={{
+              Root: {
+                style: {
+                  width: '375px',
+                  marginRight: theme.sizing.scale600,
+                },
+              },
+            }}
+          />
+        </FormControl>
+      </span>
+      <Button
+        onClick={() => {
+          inputRef.current && inputRef.current.focus();
+        }}
+      >
+        Click to focus
+      </Button>
+    </div>
+  );
+}
+
+export default Example;

--- a/documentation-site/pages/components/combobox.mdx
+++ b/documentation-site/pages/components/combobox.mdx
@@ -19,6 +19,7 @@ import AsyncOptions from 'examples/combobox/async-options.js';
 import FilteredOptions from 'examples/combobox/filtered-options.js';
 import ReplacementNode from 'examples/combobox/replacement-node.js';
 import InputOverrides from 'examples/combobox/input-overrides.js';
+import Focus from 'examples/combobox/focus.js';
 
 export default Layout;
 
@@ -58,6 +59,10 @@ to provide a placeholder, but can be applied to any Input props.
 
 <Example title="Input props" path="combobox/input-overrides.js">
   <InputOverrides />
+</Example>
+
+<Example title="Focus and inputRef" path="combobox/focus.js">
+  <Focus />
 </Example>
 
 ## API

--- a/gitpkg.config.js
+++ b/gitpkg.config.js
@@ -1,0 +1,9 @@
+const {execSync} = require('child_process');
+
+module.exports = () => ({
+  getTagName: pkg =>
+    `${pkg.name}-v${pkg.version}-gitpkg-${execSync(
+      'git rev-parse --short HEAD',
+      {encoding: 'utf-8'},
+    ).trim()}`,
+});

--- a/src/combobox/__tests__/combobox.test.js
+++ b/src/combobox/__tests__/combobox.test.js
@@ -378,4 +378,25 @@ describe('combobox', () => {
     const closed = container.querySelector('ul');
     expect(closed).toBeNull();
   });
+
+  it('forwards inputRef from props', () => {
+    const inputRef = React.createRef();
+    const {container} = render(
+      <Combobox
+        autocomplete={false}
+        mapOptionToString={o => o}
+        onChange={() => {}}
+        options={options}
+        value={''}
+        inputRef={inputRef}
+      />,
+      {container: document.body},
+    );
+
+    expect(inputRef.current).toBeDefined();
+    // $FlowFixMe
+    inputRef.current.focus();
+    const inputNode = container.querySelector('input');
+    expect(inputNode).toBe(document.activeElement);
+  });
 });

--- a/src/combobox/combobox.js
+++ b/src/combobox/combobox.js
@@ -45,6 +45,7 @@ function Combobox<OptionT>(props: PropsT<OptionT>) {
     options,
     overrides = {},
     positive = false,
+    inputRef: forwardInputRef,
     size = SIZE.default,
     value,
   } = props;
@@ -189,6 +190,17 @@ function Combobox<OptionT>(props: PropsT<OptionT>) {
     setTempValue(event.target.value);
   }
 
+  function handleInputRef(input) {
+    inputRef.current = input;
+    if (forwardInputRef) {
+      if (typeof forwardInputRef === 'function') {
+        forwardInputRef(input);
+      } else {
+        forwardInputRef.current = input;
+      }
+    }
+  }
+
   function handleOptionClick(index) {
     let clickedOption = options[index];
     if (clickedOption) {
@@ -292,7 +304,7 @@ function Combobox<OptionT>(props: PropsT<OptionT>) {
           {...inputContainerProps}
         >
           <OverriddenInput
-            inputRef={inputRef}
+            inputRef={handleInputRef}
             aria-activedescendant={
               selectionIndex >= 0 ? activeDescendantId : undefined
             }

--- a/src/combobox/index.d.ts
+++ b/src/combobox/index.d.ts
@@ -30,6 +30,7 @@ export type PropsT<OptionT = unknown> = {
   onSubmit?: (params: {closeListbox: () => void; value: string}) => any;
   options: OptionT;
   overrides?: ComboboxOverrides;
+  inputRef?: React.Ref<HTMLInputElement>;
   size?: SIZE[keyof SIZE];
   value: string;
 };

--- a/src/combobox/types.js
+++ b/src/combobox/types.js
@@ -52,6 +52,8 @@ export type PropsT<OptionT = mixed> = {|
   |},
   // Proxies value through to Input component.
   positive?: boolean,
+  // A ref to access the inner Input component.
+  inputRef?: React.ElementRef<*>,
   // Configures the height of input and list item elements.
   size?: $Keys<typeof SIZE>,
   // Initial text provided to the input element.


### PR DESCRIPTION
I've got these changes in the `gadget-inc/baseweb/combobox-inputRef` branch that I will submit for upstream review.

In the meantime we can use this for our own fork
